### PR TITLE
Ajout compendium Carrières

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,6 @@ Ce dépôt contient un exemple minimal de système de jeu **Imperator** pour Fou
 - `styles/system.css` : styles de base.
 - `lang/fr.json` : localisations françaises.
 - `packs/competences.db` : pack d'exemple contenant quelques compétences.
+- `packs/carrieres.db` : exemples de carrières pouvant être glissées sur la fiche.
 
 Ce système propose quatre caractéristiques principales (Corpus, Charisma, Sensus, Spiritus) et un système de jets utilisant des dés à 10 faces (d10).

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -8,6 +8,7 @@
     "Corpus": "Corpus",
     "Charisma": "Charisme",
     "Sensus": "Sensus",
-    "Spiritus": "Spiritus"
+    "Spiritus": "Spiritus",
+    "Careers": "Carrières"
   }
 }

--- a/packs/carrieres.db
+++ b/packs/carrieres.db
@@ -1,0 +1,3 @@
+{"_id":"soldat","name":"Soldat","type":"career","system":{"description":"Carrière militaire"},"folder":null,"sort":0,"flags":{}}
+{"_id":"marchand","name":"Marchand","type":"career","system":{"description":"Carrière commerciale"},"folder":null,"sort":0,"flags":{}}
+{"_id":"erudit","name":"Érudit","type":"career","system":{"description":"Carrière savante"},"folder":null,"sort":0,"flags":{}}

--- a/scripts/actor.js
+++ b/scripts/actor.js
@@ -33,6 +33,7 @@ export class ImperatorActorSheet extends ActorSheet {
   getData() {
     const data = super.getData();
     data.system.skills = data.system.skills || {};
+    data.careers = this.actor.items.filter(i => i.type === 'career');
     data.charLabels = {
       corpus: game.i18n.localize('IMPERATOR.Corpus'),
       charisma: game.i18n.localize('IMPERATOR.Charisma'),
@@ -45,6 +46,10 @@ export class ImperatorActorSheet extends ActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
     html.find('button[data-action="roll"]').click(this._onRoll.bind(this));
+    html.find('.item-delete').click(ev => {
+      const li = ev.currentTarget.closest('.item');
+      if (li) this.actor.deleteEmbeddedDocuments('Item', [li.dataset.itemId]);
+    });
   }
 
   _onRoll(event) {

--- a/styles/system.css
+++ b/styles/system.css
@@ -12,3 +12,13 @@
 .char-row label, .skill-name {
   flex: 1 0 120px;
 }
+
+.career {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.25em;
+}
+
+.career-name {
+  flex: 1 0 120px;
+}

--- a/system.json
+++ b/system.json
@@ -13,6 +13,13 @@
       "path": "packs/competences.db",
       "type": "Item",
       "system": "imperator"
+    },
+    {
+      "name": "carrieres",
+      "label": "Carrières",
+      "path": "packs/carrieres.db",
+      "type": "Item",
+      "system": "imperator"
     }
   ],
   "languages": [

--- a/templates/actor-sheet.html
+++ b/templates/actor-sheet.html
@@ -23,6 +23,17 @@
       {{/each}}
     </ul>
   </section>
+  <section class="careers">
+    <h2 data-localize="IMPERATOR.Careers">Carrières</h2>
+    <ul class="career-list">
+      {{#each careers}}
+      <li class="career item" data-item-id="{{_id}}">
+        <span class="career-name">{{name}}</span>
+        <button type="button" class="item-delete">✖</button>
+      </li>
+      {{/each}}
+    </ul>
+  </section>
   <section class="health">
     <label data-localize="IMPERATOR.HP">PV</label>
     <input type="number" name="system.hp" value="{{system.hp}}" disabled />


### PR DESCRIPTION
## Summary
- pack *carrières* disponible dans `system.json`
- contenu initial de carrières
- localisation fr pour les carrières
- affichage et suppression des carrières dans la fiche
- style de base pour la liste

## Testing
- `npm test` *(fails: package.json absent)*

------
https://chatgpt.com/codex/tasks/task_e_6852bc37f0048333a5aae38be6b8f6f5